### PR TITLE
Render bookmark separators as hr lines

### DIFF
--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -218,6 +218,7 @@ export const Grid = observer(function Grid() {
     };
 
     const sortable = Sortable.create(gridRef.current!, {
+      filter: ".Divider",
       animation: 150,
       delay: 100,
       delayOnTouchOnly: true,
@@ -371,17 +372,26 @@ export const Grid = observer(function Grid() {
 });
 
 const Dials = observer(function Dials() {
-  return bookmarks.bookmarks.map(({ id, name, title, type, index, url }) => (
-    <Dial
-      {...{
-        id,
-        name,
-        title,
-        index,
-        type,
-        url,
-      }}
-      key={id}
-    />
-  ));
+  return bookmarks.bookmarks.map(({ id, name, title, type, index, url }) => {
+    if (type === "divider") {
+      return settings.showDividers ? <Divider key={id} /> : null;
+    }
+    return (
+      <Dial
+        {...{
+          id,
+          name,
+          title,
+          index,
+          type,
+          url,
+        }}
+        key={id}
+      />
+    );
+  });
 });
+
+function Divider() {
+  return <hr className="Divider" />;
+}

--- a/src/components/Grid/styles.css
+++ b/src/components/Grid/styles.css
@@ -174,6 +174,30 @@
   }
 }
 
+.Divider {
+  grid-column: 1 / -1;
+  width: 50%;
+  margin: 0 auto;
+  border: none;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    currentColor 30%,
+    currentColor 70%,
+    transparent
+  );
+  opacity: 0.3;
+
+  .color-scheme-light & {
+    color: #424242;
+  }
+
+  .color-scheme-dark & {
+    color: #e0e0e0;
+  }
+}
+
 /* Drag and drop styles */
 .folder-drop-target {
   outline: 4px dashed #42a5f5 !important;

--- a/src/components/SettingsContent/index.tsx
+++ b/src/components/SettingsContent/index.tsx
@@ -22,6 +22,7 @@ export const SettingsContent = observer(function SettingsContent() {
     handleDialSize,
     handleMaxColumns,
     handleNewTab,
+    handleShowDividers,
     handleShowTitle,
     handleSquareDials,
     handleSwitchTitle,
@@ -384,6 +385,27 @@ export const SettingsContent = observer(function SettingsContent() {
             onClick={() => handleShowTitle(!settings.showTitle)}
             className="switch-root"
             checked={settings.showTitle as boolean}
+          >
+            <span className="switch-thumb" />
+          </Switch>
+        </div>
+      </div>
+      <div className="setting-wrapper setting-group">
+        <div className="setting-label">
+          <div className="setting-title" id="show-dividers-title">
+            Show Dividers
+          </div>
+          <div className="setting-description" id="show-dividers-description">
+            Render bookmark separators as horizontal divider lines.
+          </div>
+        </div>
+        <div className="setting-option toggle">
+          <Switch
+            aria-labelledby="show-dividers-title"
+            aria-describedby="show-dividers-description"
+            onClick={() => handleShowDividers(!settings.showDividers)}
+            className="switch-root"
+            checked={settings.showDividers as boolean}
           >
             <span className="switch-thumb" />
           </Switch>

--- a/src/components/SettingsContent/index.tsx
+++ b/src/components/SettingsContent/index.tsx
@@ -390,27 +390,29 @@ export const SettingsContent = observer(function SettingsContent() {
           </Switch>
         </div>
       </div>
-      <div className="setting-wrapper setting-group">
-        <div className="setting-label">
-          <div className="setting-title" id="show-dividers-title">
-            Show Dividers
+      {!__CHROME__ && (
+        <div className="setting-wrapper setting-group">
+          <div className="setting-label">
+            <div className="setting-title" id="show-dividers-title">
+              Show Dividers
+            </div>
+            <div className="setting-description" id="show-dividers-description">
+              Render bookmark separators as horizontal divider lines.
+            </div>
           </div>
-          <div className="setting-description" id="show-dividers-description">
-            Render bookmark separators as horizontal divider lines.
+          <div className="setting-option toggle">
+            <Switch
+              aria-labelledby="show-dividers-title"
+              aria-describedby="show-dividers-description"
+              onClick={() => handleShowDividers(!settings.showDividers)}
+              className="switch-root"
+              checked={settings.showDividers as boolean}
+            >
+              <span className="switch-thumb" />
+            </Switch>
           </div>
         </div>
-        <div className="setting-option toggle">
-          <Switch
-            aria-labelledby="show-dividers-title"
-            aria-describedby="show-dividers-description"
-            onClick={() => handleShowDividers(!settings.showDividers)}
-            className="switch-root"
-            checked={settings.showDividers as boolean}
-          >
-            <span className="switch-thumb" />
-          </Switch>
-        </div>
-      </div>
+      )}
       <div className="setting-wrapper setting-group">
         <div className="setting-label">
           <div className="setting-title" id="switch-title-title">

--- a/src/stores/useSettings/index.ts
+++ b/src/stores/useSettings/index.ts
@@ -91,6 +91,7 @@ const defaultSettings = {
   maxColumns: "7",
   newTab: false,
   showAlertBanner: !lastVersion || isUpgrade,
+  showDividers: false,
   showTitle: true,
   squareDials: false,
   switchTitle: false,
@@ -120,6 +121,8 @@ export const settings = makeAutoObservable({
     storage[`${apiVersion}-max-columns`] || defaultSettings.maxColumns,
   newTab: storage[`${apiVersion}-new-tab`] ?? defaultSettings.newTab,
   showAlertBanner: defaultSettings.showAlertBanner,
+  showDividers:
+    storage[`${apiVersion}-show-dividers`] ?? defaultSettings.showDividers,
   showTitle: storage[`${apiVersion}-show-title`] ?? defaultSettings.showTitle,
   squareDials:
     storage[`${apiVersion}-square-dials`] ?? defaultSettings.squareDials,
@@ -236,6 +239,11 @@ export const settings = makeAutoObservable({
     };
     i.click();
   },
+  handleShowDividers(value: boolean) {
+    browser.storage.local.set({ [`${apiVersion}-show-dividers`]: value });
+    settings.showDividers = value;
+    bc.postMessage({ showDividers: value });
+  },
   handleShowTitle(value: boolean) {
     browser.storage.local.set({ [`${apiVersion}-show-title`]: value });
     settings.showTitle = value;
@@ -322,6 +330,7 @@ export const settings = makeAutoObservable({
     settings.handleDialSize(defaultSettings.dialSize);
     settings.handleMaxColumns(defaultSettings.maxColumns);
     settings.handleNewTab(defaultSettings.newTab);
+    settings.handleShowDividers(defaultSettings.showDividers);
     settings.handleShowTitle(defaultSettings.showTitle);
     settings.handleSquareDials(defaultSettings.squareDials);
     settings.handleSwitchTitle(defaultSettings.switchTitle);

--- a/src/types/filter.d.ts
+++ b/src/types/filter.d.ts
@@ -1,7 +1,7 @@
 interface FilteredBookmark {
   title?: string;
   url?: string;
-  type: "bookmark" | "folder";
+  type: "bookmark" | "folder" | "divider";
   name: string[];
   id: string;
   parentId?: string;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -50,8 +50,7 @@ function filter(bookmarks: Bookmarks.BookmarkTreeNode[]): FilteredBookmark[] {
         url,
         type: bookmarkType,
       }: Bookmarks.BookmarkTreeNode): FilteredBookmark => {
-        // Firefox native separator or Chrome convention (title "---")
-        if (bookmarkType === "separator" || title === "---") {
+        if (bookmarkType === "separator") {
           return { type: "divider", name: [], id, parentId, index };
         }
         if (url) {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -35,11 +35,12 @@ function getLinkName(url: string): string[] {
 
 function filter(bookmarks: Bookmarks.BookmarkTreeNode[]): FilteredBookmark[] {
   return bookmarks
-    .filter(
-      ({ url = "", type }: Bookmarks.BookmarkTreeNode) =>
-        !url.match(/^(javascript|place|about|chrome|edge|file|data|blob):/i) &&
-        type !== "separator",
-    )
+    .filter(({ url = "", type }: Bookmarks.BookmarkTreeNode) => {
+      if (type === "separator") return true;
+      return !url.match(
+        /^(javascript|place|about|chrome|edge|file|data|blob):/i,
+      );
+    })
     .map(
       ({
         id,
@@ -47,7 +48,12 @@ function filter(bookmarks: Bookmarks.BookmarkTreeNode[]): FilteredBookmark[] {
         parentId,
         title,
         url,
+        type: bookmarkType,
       }: Bookmarks.BookmarkTreeNode): FilteredBookmark => {
+        // Firefox native separator or Chrome convention (title "---")
+        if (bookmarkType === "separator" || title === "---") {
+          return { type: "divider", name: [], id, parentId, index };
+        }
         if (url) {
           const name = getLinkName(url);
           return { title, url, type: "bookmark", name, id, parentId, index };


### PR DESCRIPTION
Implementation for https://github.com/lucaseverett/easy-speed-dial/issues/57.

@lucaseverett as you pointed out in https://github.com/lucaseverett/easy-speed-dial/issues/57 the "divider" is not supported in chrome (yet?). The implementation in this PR uses the runtime check for the item type (`type === "separator"`) which should be compatible with chromium-based browsers since we it's expected that such element won't be returned on chrome.

The knob in settings is guarded by `!__CHROME__` and will be visible only on firefox-based browsers.

#### Screens

<img width="1978" height="1426" alt="Screenshot From 2026-03-20 21-34-39" src="https://github.com/user-attachments/assets/1266b627-1dd5-444b-a005-f77abfd903b3" />

Settings:

<img width="543" height="422" alt="Screenshot From 2026-03-20 21-35-59" src="https://github.com/user-attachments/assets/ec794382-9738-4b97-8fda-0ad7085c3413" />
