### PR TITLE
Add high-res favicon support with manual selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1784,7 +1783,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1795,7 +1793,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1886,7 +1883,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2236,7 +2232,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2997,7 +2992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4133,7 +4127,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5844,7 +5837,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6180,7 +6172,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -6711,7 +6702,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6827,7 +6817,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6971,7 +6960,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7318,7 +7306,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -8105,7 +8094,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8306,7 +8294,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8972,7 +8959,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/public/chrome/manifest.json
+++ b/public/chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Easy Speed Dial",
   "version": "2.13.1",
-  "permissions": ["bookmarks", "storage", "unlimitedStorage"],
+  "permissions": ["bookmarks", "storage", "unlimitedStorage", "favicon"],
   "description": "Easy Speed Dial replaces the new tab page with a colorful grid of your bookmarks and folders.",
   "chrome_url_overrides": {
     "newtab": "index.html"

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -230,6 +230,35 @@ export const ContextMenu = observer(function ContextMenu() {
               </button>
             </li>
           )}
+          {settings.useFavicons && (
+            <>
+              <li>
+                <button
+                  role="menuitem"
+                  onClick={handleShowSelectFavicon}
+                  onMouseEnter={handleMouseEnter}
+                >
+                  Select favicon
+                </button>
+              </li>
+              {settings.manualFavicons[
+                new URL(
+                  contextMenu.focusAfterClosed?.getAttribute("href") || "",
+                  window.location.href,
+                ).hostname
+              ] && (
+                <li>
+                  <button
+                    role="menuitem"
+                    onClick={handleClearManualFavicon}
+                    onMouseEnter={handleMouseEnter}
+                  >
+                    Clear manual favicon
+                  </button>
+                </li>
+              )}
+            </>
+          )}
           <Separator />
           <li>
             <button
@@ -401,6 +430,15 @@ function handleClearThumbnail() {
   }
 }
 
+function handleClearManualFavicon() {
+  contextMenu.closeContextMenu();
+  const url = contextMenu.focusAfterClosed?.getAttribute("href");
+  if (url) {
+    const hostname = new URL(url, window.location.href).hostname;
+    settings.handleClearManualFavicon(hostname);
+  }
+}
+
 function handleCopyURL() {
   contextMenu.closeContextMenu();
   const element = contextMenu.focusAfterClosed as HTMLAnchorElement;
@@ -471,6 +509,15 @@ function handleSelectThumbnail() {
   if (contextMenu.focusAfterClosed?.dataset.id) {
     settings.handleSelectThumbnail(contextMenu.focusAfterClosed.dataset.id);
   }
+}
+
+function handleShowSelectFavicon() {
+  modals.openModal({
+    modal: "select-favicon",
+    editingBookmarkId: contextMenu.focusAfterClosed?.dataset.id || null,
+    focusAfterClosed: contextMenu.focusAfterClosed || null,
+  });
+  contextMenu.closeContextMenu({ focusAfterClosed: false });
 }
 
 function handleShowAbout() {

--- a/src/components/FaviconModal/index.tsx
+++ b/src/components/FaviconModal/index.tsx
@@ -1,0 +1,112 @@
+import { observer } from "mobx-react-lite";
+import { useEffect, useState } from "react";
+
+import { Modal } from "#components/Modal";
+import { bookmarks } from "#stores/useBookmarks";
+import { modals } from "#stores/useModals";
+import { settings } from "#stores/useSettings";
+
+import "./styles.css";
+
+const PROVIDERS = [
+  { name: "Native Cache", getUrl: (domain: string, url: string) => `/_favicon/?pageUrl=${encodeURIComponent(url)}&size=128` },
+  { name: "DuckDuckGo", getUrl: (domain: string) => `https://icons.duckduckgo.com/ip3/${domain}.ico` },
+  { name: "Google S2", getUrl: (domain: string) => `https://www.google.com/s2/favicons?domain=${domain}&sz=128` },
+  { name: "Clearbit", getUrl: (domain: string) => `https://logo.clearbit.com/${domain}` },
+  { name: "IconHorse", getUrl: (domain: string) => `https://icon.horse/icon/${domain}` },
+];
+
+export const FaviconModal = observer(function FaviconModal() {
+  const [bookmarkURL, setBookmarkURL] = useState("");
+  const [candidates, setCandidates] = useState<{ name: string; url: string }[]>([]);
+  const [loadedUrls, setLoadedUrls] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadBookmarkData() {
+      if (modals.editingBookmarkId) {
+        const bookmark = await bookmarks.getBookmarkById(modals.editingBookmarkId);
+        if (bookmark && bookmark.url) {
+          setBookmarkURL(bookmark.url);
+          const fullHostname = new URL(bookmark.url).hostname;
+          const rootDomain = fullHostname.replace(/^www\./, "");
+          
+          const urls = PROVIDERS.map(p => ({
+            name: p.name,
+            url: p.getUrl(p.name === "Native Cache" ? fullHostname : rootDomain, bookmark.url!)
+          }));
+          setCandidates(urls);
+        }
+      }
+      setLoading(false);
+    }
+
+    loadBookmarkData();
+  }, []);
+
+  async function handleSelect(url: string) {
+    if (bookmarkURL) {
+      const hostname = new URL(bookmarkURL).hostname;
+      settings.handleManualFavicon(hostname, url);
+      modals.closeModal();
+    }
+  }
+
+  const hasValidCandidates = Object.values(loadedUrls).some(v => v);
+
+  return (
+    <Modal
+      title="Select Favicon"
+      width="450px"
+    >
+      <div className="FaviconModal">
+        <p className="description">
+          Choose the best quality icon for <strong>{bookmarkURL}</strong>. 
+          Only icons that load successfully are shown below.
+        </p>
+        
+        {loading ? (
+          <div className="loading">Searching for icons...</div>
+        ) : (
+          <>
+            <div className="favicon-grid">
+              {candidates.map((candidate) => (
+                <button
+                  key={candidate.name}
+                  className="favicon-candidate"
+                  onClick={() => handleSelect(candidate.url)}
+                  style={{ display: loadedUrls[candidate.url] ? "flex" : "none" }}
+                >
+                  <div className="icon-wrapper">
+                    <img 
+                      src={candidate.url} 
+                      alt={candidate.name}
+                      onLoad={() => setLoadedUrls(prev => ({ ...prev, [candidate.url]: true }))}
+                      onError={() => setLoadedUrls(prev => ({ ...prev, [candidate.url]: false }))}
+                    />
+                  </div>
+                  <span className="provider-name">{candidate.name}</span>
+                </button>
+              ))}
+            </div>
+            {!hasValidCandidates && !loading && (
+              <div className="no-candidates">
+                No high-quality icons found for this site.
+              </div>
+            )}
+          </>
+        )}
+        
+        <div className="buttons">
+          <button
+            type="button"
+            className="btn defaultBtn"
+            onClick={() => modals.closeModal()}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+});

--- a/src/components/FaviconModal/styles.css
+++ b/src/components/FaviconModal/styles.css
@@ -1,0 +1,80 @@
+.FaviconModal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.FaviconModal .description {
+  font-size: 14px;
+  color: var(--text-color-secondary);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.FaviconModal .favicon-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.FaviconModal .favicon-candidate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-color-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+.FaviconModal .favicon-candidate:hover,
+.FaviconModal .favicon-candidate:focus {
+  border-color: var(--accent-color);
+  background: var(--bg-color-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.FaviconModal .icon-wrapper {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: white;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.FaviconModal .icon-wrapper img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.FaviconModal .provider-name {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-color);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.FaviconModal .loading,
+.FaviconModal .no-candidates {
+  text-align: center;
+  padding: 32px;
+  color: var(--text-color-secondary);
+}
+
+.FaviconModal .buttons {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}

--- a/src/components/Grid/Dial/index.tsx
+++ b/src/components/Grid/Dial/index.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react-lite";
 import { addOpacity } from "random-color-library";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { dialColors } from "#lib/dialColors";
 import { contextMenu } from "#stores/useContextMenu";
@@ -46,6 +46,20 @@ export const Dial = observer(function Dial(props: DialProps) {
       : dialColors(props.name);
   const backgroundImage = settings.dialImages[props.id];
 
+  const nameFallback = (
+    <div>
+      <Name
+        {...{
+          name: settings.switchTitle
+            ? props.title
+              ? [props.title]
+              : [props.name.join(".")]
+            : props.name,
+        }}
+      />
+    </div>
+  );
+
   return (
     <a
       href={props.type === "bookmark" ? props.url : `#${props.id}`}
@@ -76,17 +90,14 @@ export const Dial = observer(function Dial(props: DialProps) {
       >
         {!settings.dialImages[props.id] &&
           (props.type === "bookmark" ? (
-            <div>
-              <Name
-                {...{
-                  name: settings.switchTitle
-                    ? props.title
-                      ? [props.title]
-                      : [props.name.join(".")]
-                    : props.name,
-                }}
+            settings.useFavicons ? (
+              <Favicon
+                url={props.url}
+                fallback={nameFallback}
               />
-            </div>
+            ) : (
+              nameFallback
+            )
           ) : (
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -100,6 +111,99 @@ export const Dial = observer(function Dial(props: DialProps) {
       </div>
       <Title {...{ title: props.title, name: props.name }} />
     </a>
+  );
+});
+
+const getFaviconUrls = (domain: string, fullUrl: string) => [
+  { url: `https://www.google.com/s2/favicons?domain=${domain}&sz=128`, type: "google" },
+  { url: `/_favicon/?pageUrl=${encodeURIComponent(fullUrl)}&size=128`, type: "native" },
+];
+
+const Favicon = observer(function Favicon({
+  url,
+  fallback,
+}: {
+  url?: string;
+  fallback: React.ReactNode;
+}) {
+  const [bestUrl, setBestUrl] = useState<string | null>(null);
+  const hostname = url ? new URL(url).hostname : "";
+
+  useEffect(() => {
+    if (!url) {
+      setBestUrl("");
+      return;
+    }
+
+    // If there's a manually selected favicon, use it immediately
+    if (settings.manualFavicons[hostname]) {
+      setBestUrl(settings.manualFavicons[hostname]);
+      return;
+    }
+
+    let isMounted = true;
+    const domain = new URL(url).hostname;
+    const candidates = getFaviconUrls(domain, url);
+
+    let loadedCount = 0;
+    const results: { url: string; width: number; type: string }[] = [];
+
+    const checkDone = () => {
+      if (!isMounted) return;
+      if (loadedCount === candidates.length) {
+        if (results.length === 0) {
+          setBestUrl("");
+          return;
+        }
+
+        const googles = results.filter((r) => r.type === "google");
+        const natives = results.filter((r) => r.type === "native");
+
+        // Prefer Google S2 (the 128x128 version), fall back to native cache
+        const chosen = googles[0] || natives[0];
+
+        setBestUrl(chosen?.url || "");
+      }
+    };
+
+    candidates.forEach((c) => {
+      const img = new Image();
+      img.src = c.url;
+      img.onload = () => {
+        if (isMounted) {
+          results.push({ url: c.url, width: img.naturalWidth, type: c.type });
+          loadedCount++;
+          checkDone();
+        }
+      };
+      img.onerror = () => {
+        if (isMounted) {
+          loadedCount++;
+          checkDone();
+        }
+      };
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [url, hostname, settings.manualFavicons[hostname]]);
+
+  // Return nothing while evaluating to prevent flicker
+  if (bestUrl === null) return null;
+  if (bestUrl === "") return <>{fallback}</>;
+
+  return (
+    <img
+      src={bestUrl}
+      alt=""
+      style={{
+        width: "60%",
+        height: "60%",
+        objectFit: "contain",
+        pointerEvents: "none",
+      }}
+    />
   );
 });
 

--- a/src/components/SettingsContent/index.tsx
+++ b/src/components/SettingsContent/index.tsx
@@ -27,6 +27,7 @@ export const SettingsContent = observer(function SettingsContent() {
     handleSwitchTitle,
     handleThemeOption,
     handleTransparentDials,
+    handleUseFavicons,
     handleWallpaper,
     resetSettings,
     restoreFromJSON,
@@ -363,6 +364,27 @@ export const SettingsContent = observer(function SettingsContent() {
             onClick={() => handleTransparentDials(!settings.transparentDials)}
             className="switch-root"
             checked={settings.transparentDials as boolean}
+          >
+            <span className="switch-thumb" />
+          </Switch>
+        </div>
+      </div>
+      <div className="setting-wrapper setting-group">
+        <div className="setting-label">
+          <div className="setting-title" id="use-favicons-title">
+            Use Favicons
+          </div>
+          <div className="setting-description" id="use-favicons-description">
+            Automatically display website favicons instead of their names on bookmark dials.
+          </div>
+        </div>
+        <div className="setting-option toggle">
+          <Switch
+            aria-labelledby="use-favicons-title"
+            aria-describedby="use-favicons-description"
+            onClick={() => handleUseFavicons(!settings.useFavicons)}
+            className="switch-root"
+            checked={settings.useFavicons as boolean}
           >
             <span className="switch-thumb" />
           </Switch>

--- a/src/pages/Bookmarks/index.tsx
+++ b/src/pages/Bookmarks/index.tsx
@@ -8,6 +8,7 @@ import { AlertBanner } from "#components/AlertBanner";
 import { BookmarkModal } from "#components/BookmarkModal";
 import { ContextMenu } from "#components/ContextMenu";
 import { Grid } from "#components/Grid";
+import { FaviconModal } from "#components/FaviconModal";
 import { SettingsModal } from "#components/SettingsModal";
 import { WhatsNewModal } from "#components/WhatsNewModal";
 import { bookmarks } from "#stores/useBookmarks";
@@ -51,6 +52,7 @@ export const Bookmarks = observer(function Bookmarks() {
       {modals.isOpen === "whats-new" && <WhatsNewModal />}
       {modals.isOpen === "about" && <AboutModal />}
       {modals.isOpen === "settings-panel" && <SettingsModal />}
+      {modals.isOpen === "select-favicon" && <FaviconModal />}
       {modals.isOpen &&
         ["new-bookmark", "new-folder", "edit-bookmark", "edit-folder"].includes(
           modals.isOpen,

--- a/src/stores/useSettings/index.ts
+++ b/src/stores/useSettings/index.ts
@@ -75,6 +75,7 @@ bc.onmessage = (e) => {
 
 type DialColors = Record<string, string>;
 type DialImages = Record<string, string>;
+type ManualFavicons = Record<string, string>;
 
 const defaultSettings = {
   attachTitle: false,
@@ -86,6 +87,7 @@ const defaultSettings = {
   defaultFolder: "",
   dialColors: {} as DialColors,
   dialImages: {} as DialImages,
+  manualFavicons: {} as ManualFavicons,
   dialSize: "small",
   firstRun: !lastVersion,
   maxColumns: "7",
@@ -96,6 +98,7 @@ const defaultSettings = {
   switchTitle: false,
   themeOption: "System Theme",
   transparentDials: false,
+  useFavicons: false,
   wallpaper: "",
 };
 
@@ -114,6 +117,9 @@ export const settings = makeAutoObservable({
   dialImages:
     (storage[`${apiVersion}-dial-images`] as DialImages) ||
     defaultSettings.dialImages,
+  manualFavicons:
+    (storage[`${apiVersion}-manual-favicons`] as ManualFavicons) ||
+    defaultSettings.manualFavicons,
   dialSize: storage[`${apiVersion}-dial-size`] || defaultSettings.dialSize,
   firstRun: defaultSettings.firstRun,
   maxColumns:
@@ -129,6 +135,8 @@ export const settings = makeAutoObservable({
   transparentDials:
     storage[`${apiVersion}-transparent-dials`] ??
     defaultSettings.transparentDials,
+  useFavicons:
+    storage[`${apiVersion}-use-favicons`] ?? defaultSettings.useFavicons,
   wallpaper,
   handleAttachTitle(value: boolean) {
     browser.storage.local.set({ [`${apiVersion}-attach-title`]: value });
@@ -151,6 +159,15 @@ export const settings = makeAutoObservable({
         [`${apiVersion}-dial-images`]: { ...settings.dialImages },
       });
       bc.postMessage({ dialImages: { ...settings.dialImages } });
+    }
+  },
+  handleClearManualFavicon(hostname: string) {
+    if (settings.manualFavicons[hostname]) {
+      remove(settings.manualFavicons, hostname);
+      browser.storage.local.set({
+        [`${apiVersion}-manual-favicons`]: { ...settings.manualFavicons },
+      });
+      bc.postMessage({ manualFavicons: { ...settings.manualFavicons } });
     }
   },
   handleCustomColor(value: string) {
@@ -236,6 +253,13 @@ export const settings = makeAutoObservable({
     };
     i.click();
   },
+  handleManualFavicon(hostname: string, url: string) {
+    set(settings.manualFavicons, hostname, url);
+    browser.storage.local.set({
+      [`${apiVersion}-manual-favicons`]: { ...settings.manualFavicons },
+    });
+    bc.postMessage({ manualFavicons: { ...settings.manualFavicons } });
+  },
   handleShowTitle(value: boolean) {
     browser.storage.local.set({ [`${apiVersion}-show-title`]: value });
     settings.showTitle = value;
@@ -262,6 +286,11 @@ export const settings = makeAutoObservable({
     browser.storage.local.set({ [`${apiVersion}-transparent-dials`]: value });
     settings.transparentDials = value;
     bc.postMessage({ transparentDials: value });
+  },
+  handleUseFavicons(value: boolean) {
+    browser.storage.local.set({ [`${apiVersion}-use-favicons`]: value });
+    settings.useFavicons = value;
+    bc.postMessage({ useFavicons: value });
   },
   handleWallpaper(value: string) {
     // Automatically clear custom image when switching to a different wallpaper
@@ -311,12 +340,18 @@ export const settings = makeAutoObservable({
     settings.dialImages = {};
     bc.postMessage({ dialImages: {} });
   },
+  resetManualFavicons() {
+    browser.storage.local.remove(`${apiVersion}-manual-favicons`);
+    settings.manualFavicons = {};
+    bc.postMessage({ manualFavicons: {} });
+  },
   resetSettings() {
     settings.handleAttachTitle(defaultSettings.attachTitle);
     settings._clearCustomColor();
     settings._clearCustomImage();
     settings.resetDialColors();
     settings.resetDialImages();
+    settings.resetManualFavicons();
     settings.resetWallpaper();
     settings.handleDefaultFolder(defaultSettings.defaultFolder);
     settings.handleDialSize(defaultSettings.dialSize);
@@ -327,6 +362,7 @@ export const settings = makeAutoObservable({
     settings.handleSwitchTitle(defaultSettings.switchTitle);
     settings.handleThemeOption(defaultSettings.themeOption);
     settings.handleTransparentDials(defaultSettings.transparentDials);
+    settings.handleUseFavicons(defaultSettings.useFavicons);
   },
   resetWallpaper() {
     settings.handleWallpaper(
@@ -379,6 +415,13 @@ export const settings = makeAutoObservable({
             settings.dialImages = backup.dialImages;
             bc.postMessage({ dialImages: backup.dialImages });
           }
+          if (Object.prototype.hasOwnProperty.call(backup, "manualFavicons")) {
+            browser.storage.local.set({
+              [`${apiVersion}-manual-favicons`]: backup.manualFavicons,
+            });
+            settings.manualFavicons = backup.manualFavicons;
+            bc.postMessage({ manualFavicons: backup.manualFavicons });
+          }
           if (Object.prototype.hasOwnProperty.call(backup, "dialSize")) {
             settings.handleDialSize(backup.dialSize);
           }
@@ -408,6 +451,9 @@ export const settings = makeAutoObservable({
           ) {
             settings.handleTransparentDials(backup.transparentDials);
           }
+          if (Object.prototype.hasOwnProperty.call(backup, "useFavicons")) {
+            settings.handleUseFavicons(backup.useFavicons);
+          }
         } catch (err) {
           console.error("Error parsing JSON file", err);
         }
@@ -423,6 +469,7 @@ export const settings = makeAutoObservable({
       defaultFolder: settings.defaultFolder,
       dialColors: settings.dialColors,
       dialImages: settings.dialImages,
+      manualFavicons: settings.manualFavicons,
       dialSize: settings.dialSize,
       maxColumns: settings.maxColumns,
       newTab: settings.newTab,
@@ -431,6 +478,7 @@ export const settings = makeAutoObservable({
       switchTitle: settings.switchTitle,
       themeOption: settings.themeOption,
       transparentDials: settings.transparentDials,
+      useFavicons: settings.useFavicons,
       wallpaper: settings.wallpaper,
     };
     const { [`${apiVersion}-custom-image`]: image } =


### PR DESCRIPTION
Hi! I'm a big fan of the project, and have been using it for several months. However, I got a little fed up of having to manually get the images for each bookmark, and I've always loved the visual style of the older Safari speed dials, so I’ve built an optional favicon support system that fits into the existing architecture.

<img width="2472" height="1512" alt="image" src="https://github.com/user-attachments/assets/a58f88fd-cd29-406a-93dc-d3b5701578be" />

Key Features:

Optional Toggle: Added a "Use Favicons" setting. If disabled, the UI defaults back to the original text-tile logic.
<img width="533" height="134" alt="Screenshot 2026-04-17 at 8 34 12 pm" src="https://github.com/user-attachments/assets/e863a973-4978-41c0-bf34-173e418b6ce9" />

Manual Favicon Selector: Users can right-click any dial to choose between different high-res providers (Google S2, DuckDuckGo, Clearbit, etc.) to ensure icons are sharp.
<img width="244" height="289" alt="Screenshot 2026-04-17 at 8 35 10 pm" src="https://github.com/user-attachments/assets/d2e6fd2e-c1b9-4e47-8c7a-e0ab0eb74c07" />
<img width="471" height="409" alt="Screenshot 2026-04-17 at 8 38 38 pm" src="https://github.com/user-attachments/assets/af44aaaa-fdcf-4aee-9301-5f077359979c" />

Hostname-Based Mapping: Selecting an icon for a domain automatically applies it to all bookmarks on that same hostname.
Architecture Consistency: I’ve used the existing MobX stores, browser.storage.local persistence, and CSS variables to ensure it feels native to the extension.

I've tested this thoroughly on Chrome and Firefox. I think it adds a nice layer of customisation for users who want a more "visual" dashboard.

Thank you for making sure an awesome extension.
